### PR TITLE
fix: Shows cursol pointer for link row correctly

### DIFF
--- a/src/pages/landingPage/sections/Title.tsx
+++ b/src/pages/landingPage/sections/Title.tsx
@@ -30,6 +30,10 @@ const useStyles = makeStyles(theme => ({
     },
     heroContent: {
         padding: '10% 10% 10%',
+        // eslint-disable-next-line no-useless-computed-key
+        ['@media (max-width:414px)']: {
+            padding: '10% 0%',
+        },
         width: '100%',
         maxWidth: '100%',
         background: 'transparent',

--- a/src/pages/landingPage/sections/Title.tsx
+++ b/src/pages/landingPage/sections/Title.tsx
@@ -59,6 +59,7 @@ const useStyles = makeStyles(theme => ({
     link: {
         color: 'rgb(129, 133, 141)',
         cursor: 'pointer',
+        display: 'inline-block',
     },
 }));
 


### PR DESCRIPTION
Cursor pointer was showing in whole the row since <p> tag is `block` value in `display` property. So I add inline-block to fix this issue.
=before=

<img width="947" alt="image" src="https://user-images.githubusercontent.com/42575132/83822137-cbd92400-a702-11ea-9563-1ca97bdab75a.png">


![スクリーンショット 2020-06-05 午前7 41 13](https://user-images.githubusercontent.com/42575132/83822104-b532cd00-a702-11ea-95ac-6a8031f960fc.png)


=after=

<img width="510" alt="image" src="https://user-images.githubusercontent.com/42575132/83822157-d4315f00-a702-11ea-8a36-78b780b9cf41.png">


Demo: https://plasmnet-io-git-master.roy1210.now.sh/